### PR TITLE
Add Docker container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,3 +79,20 @@ jobs:
         with:
           name: vwmetrics-${{ matrix.job.pretty }}
           path: target/${{ matrix.job.target }}/release/vwmetrics
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build containers
+        uses: docker/build-push-action@v3
+        with:
+          load: true
+          tags: vwmetrics:latest
+
+      - name: Show image info
+        run: docker images

--- a/.github/workflows/latest-deploy.yml
+++ b/.github/workflows/latest-deploy.yml
@@ -1,0 +1,28 @@
+name: Latest deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build containers
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ghcr.io/Tricked-dev/vwmetrics:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM rust:1-slim AS builder
+
+WORKDIR /usr/src/vwmetrics
+
+COPY ./src /usr/src/vwmetrics/src
+COPY Cargo.toml /usr/src/vwmetrics/Cargo.toml
+COPY Cargo.lock /usr/src/vwmetrics/Cargo.lock
+
+RUN cargo build --release
+
+FROM debian:stable-slim
+
+COPY --from=builder /usr/src/vwmetrics/target/release/vwmetrics /usr/local/bin/vwmetrics
+
+USER www-data
+
+ENV HOST=0.0.0.0 PORT=3040
+
+EXPOSE 3040
+
+CMD ["/usr/local/bin/vwmetrics"]


### PR DESCRIPTION
This allows deployment as a docker container - useful when running Vaultwarden in docker too.

Notably, the container:

- Doesn't run as `root`
- Binds to all interfaces
- Uses Debian Slim as the base (`scratch` could be nice, or alpine, just needs some further testing).